### PR TITLE
X00T: downgrade NFC interface

### DIFF
--- a/configs/nfc/libnfc-nxp.conf
+++ b/configs/nfc/libnfc-nxp.conf
@@ -1,5 +1,6 @@
-## This file is used by NFC NXP NCI HAL(external/libnfc-nci/halimpl/pn547)
-## and NFC Service Java Native Interface Extensions (packages/apps/Nfc/nci/jni/extns/pn547)
+#DEVICE_MANUFACTURER=NXP
+#DEVICE_MODEL=PN553
+####ZB630_0612_conf####
 ###############################################################################
 # Application options
 # Logging Levels
@@ -14,6 +15,7 @@ NXPLOG_NCIX_LOGLEVEL=0x03
 NXPLOG_NCIR_LOGLEVEL=0x03
 NXPLOG_FWDNLD_LOGLEVEL=0x03
 NXPLOG_TML_LOGLEVEL=0x03
+NFC_DEBUG_ENABLED=0x01
 
 ###############################################################################
 # Nfc Device Node name
@@ -21,10 +23,14 @@ NXP_NFC_DEV_NODE="/dev/nq-nci"
 
 ###############################################################################
 # Extension for Mifare reader enable
+# Disable   = 0x00
+# Enable    = 0x01
 MIFARE_READER_ENABLE=0x01
 
 ###############################################################################
 # Vzw Feature enable
+# Disable   = 0x00
+# Enable    = 0x01
 VZW_FEATURE_ENABLE=0x01
 
 ###############################################################################
@@ -50,7 +56,7 @@ NXP_SYS_CLK_FREQ_SEL=0x02
 
 ###############################################################################
 # The timeout value to be used for clock request acknowledgment
-# min value = 0x01 to max = 0x06
+# min value = 0x01 (1.33 ms) to max = 0x06 (2.98 ms)
 NXP_SYS_CLOCK_TO_CFG=0x06
 
 ###############################################################################
@@ -62,19 +68,19 @@ NXP_ACT_PROP_EXTN={2F, 02, 00}
 NXP_NFC_PROFILE_EXTN={20, 02, 05, 01, A0, 44, 01, 00}
 
 ###############################################################################
-# NFCC Configuration Control
-# Allow NFCC to manage RF Config       0x01
-# Don't allow NFCC to manage RF Config 0x00
-NXP_NFC_MERGE_RF_PARAMS={20, 02, 04, 01, 85, 01, 01}
-
-###############################################################################
 # Standby enable settings
-#NXP_CORE_STANDBY={2F, 00, 01, 01}
+# Disable   = 0x00
+# Enable    = 0x01
+NXP_CORE_STANDBY={2F, 00, 01, 01}
 
 ###############################################################################
 # NXP TVDD configurations settings
 # Allow NFCC to configure External TVDD, two configurations (1 and 2) supported,
 # out of them only one can be configured at a time.
+#supported(hardware dependancy).
+#       Config 1: VUP connected to VBAT
+#       Config 2: VUP connected to external 5V
+#
 NXP_EXT_TVDD_CFG=0x02
 
 ###############################################################################
@@ -84,67 +90,214 @@ NXP_EXT_TVDD_CFG_1={20, 02, 0F, 01, A0, 0E, 0B, 31, 01, 01, 31, 00, 00, 00, 01, 
 ###############################################################################
 #config2: use DCDC in CE, use Tx_Pwr_Req, set CFG2 mode, SLALM,
 #monitoring 5V from DCDC, 3.3V for both RM and CM, DCDCWaitTime=4.2ms
-NXP_EXT_TVDD_CFG_2={20, 02, 0F, 01, A0, 0E, 0B, 11, 01, C2, B2, 00, B2, 1E, 1F, 00, D0, 0C}
-
+NXP_EXT_TVDD_CFG_2={20, 02, 0F, 01, A0, 0E, 0B, 11, 01, C2, F2, 00, BA, 1E, 1F, 00, D0, 0C}
 ###############################################################################
 # NXP RF configuration ALM/PLM settings
 # This section needs to be updated with the correct values based on the platform
-# DPC deactivated
+###############################################################################
+#  NXP RF Eval1_SLALM_CFG2_EFM_40x20 configuration settings for FW Version = 11.01.18 
+#
+#	A0, 0D, 04, 00, 42, FF, FF,           RF_CLIF_CFG_BOOT  CLIF_ANA_TX_AMPLITUDE_REG
+#	A0, 0D, 03, 02, 43, A0,               RF_CLIF_CFG_IDLE  CLIF_ANA_PBF_CONTROL_REG
+#	A0, 0D, 06, 02, 44, 00, 08, F6, 00,   RF_CLIF_CFG_IDLE  CLIF_ANA_RX_REG
+#	A0, 0D, 06, 02, 45, 80, 40, 00, 00,   RF_CLIF_CFG_IDLE  CLIF_ANA_CM_CONFIG_REG
+#	A0, 0D, 06, 02, 4A, 00, 00, 00, 00,   RF_CLIF_CFG_IDLE  CLIF_ANA_TX_SHAPE_CONTROL_REG
+#	A0, 0D, 03, 02, 40, 00,               RF_CLIF_CFG_IDLE  CLIF_ANA_NFCLD_REG
+#	A0, 0D, 03, 02, 47, 00,               RF_CLIF_CFG_IDLE  CLIF_ANA_AGC_REG
+#	A0, 0D, 06, 02, 35, 00, 3E, 00, 00,   RF_CLIF_CFG_IDLE  CLIF_AGC_INPUT_REG
+#	A0, 0D, 06, 02, 33, 0F, 40, 04, 00,   RF_CLIF_CFG_IDLE  CLIF_AGC_CONFIG0_REG
+#	A0, 0D, 06, 04, 35, F4, 05, 70, 02,   RF_CLIF_CFG_INITIATOR  CLIF_AGC_INPUT_REG
+#	A0, 0D, 06, 04, 42, F8, 40, FF, FF,   RF_CLIF_CFG_INITIATOR  CLIF_ANA_TX_AMPLITUDE_REG
+#	A0, 0D, 06, C2, 35, 00, 3E, 00, 03,   RF_CLIF_EXT_FIELD_ON  CLIF_AGC_INPUT_REG
+#	A0, 0D, 06, C2, 34, F7, 7F, 10, 08,   RF_CLIF_EXT_FIELD_ON  CLIF_AGC_CONFIG1_REG
+#	A0, 0D, 06, C2, 33, 03, 40, 04, 80,   RF_CLIF_EXT_FIELD_ON  CLIF_AGC_CONFIG0_REG
+#	A0, 0D, 06, 06, 2D, 0D, 25, 2C, 01,   RF_CLIF_CFG_TARGET  CLIF_SIGPRO_RM_CONFIG1_REG
+#	A0, 0D, 06, 06, 44, 04, 04, C4, 00,   RF_CLIF_CFG_TARGET  CLIF_ANA_RX_REG
+#	A0, 0D, 06, 06, 30, 70, 00, 18, 00,   RF_CLIF_CFG_TARGET  CLIF_SIGPRO_ADCBCM_THRESHOLD_REG
+#	A0, 0D, 06, 06, 45, 83, 60, 40, 05,   RF_CLIF_CFG_TARGET  CLIF_ANA_CM_CONFIG_REG
+#	A0, 0D, 06, 06, 42, 00, 00, FF, FF,   RF_CLIF_CFG_TARGET  CLIF_ANA_TX_AMPLITUDE_REG
+#	A0, 0D, 06, 06, 16, AE, 00, 1F, 00,   RF_CLIF_CFG_TARGET  CLIF_TX_UNDERSHOOT_CONFIG_REG
+#	A0, 0D, 03, 06, 15, 00,               RF_CLIF_CFG_TARGET  CLIF_TX_OVERSHOOT_CONFIG_REG
+#	A0, 0D, 06, 06, 37, 08, 76, 00, 00,   RF_CLIF_CFG_TARGET  CLIF_TX_CONTROL_REG
+#	A0, 0D, 06, 07, 30, 00, 00, 00, 00,   RF_CLIF_CFG_TARGET  CLIF_SIGPRO_ADCBCM_THRESHOLD_REG
+#	A0, 0D, 06, 07, 37, 00, 00, 00, 00,   RF_CLIF_CFG_TARGET  CLIF_TX_CONTROL_REG
+#	A0, 0D, 06, 07, 42, 01, 10, FF, FF,   RF_CLIF_CFG_TARGET  CLIF_ANA_TX_AMPLITUDE_REG
+#	A0, 0D, 03, 07, 3F, 08,               RF_CLIF_CFG_TARGET  CLIF_TEST_CONTROL_REG
+#	A0, 0D, 03, 32, 03, 3D,               RF_CLIF_CFG_BR_106_I_TXA  CLIF_TRANSCEIVE_CONTROL_REG
+#	A0, 0D, 04, 32, 42, F8, 40,           RF_CLIF_CFG_BR_106_I_TXA  CLIF_ANA_TX_AMPLITUDE_REG
+#	A0, 0D, 03, 32, 16, 01,               RF_CLIF_CFG_BR_106_I_TXA  CLIF_TX_UNDERSHOOT_CONFIG_REG
+#	A0, 0D, 03, 32, 15, 01,               RF_CLIF_CFG_BR_106_I_TXA  CLIF_TX_OVERSHOOT_CONFIG_REG
+#	A0, 0D, 06, 32, 4A, 53, 07, 00, 1B,   RF_CLIF_CFG_BR_106_I_TXA  CLIF_ANA_TX_SHAPE_CONTROL_REG
+#	A0, 0D, 03, 32, 0D, 24,               RF_CLIF_CFG_BR_106_I_TXA  CLIF_TX_DATA_MOD_REG
+#	A0, 0D, 03, 32, 14, 24,               RF_CLIF_CFG_BR_106_I_TXA  CLIF_TX_SYMBOL23_MOD_REG
+#	A0, 0D, 06, 34, 2D, DC, 40, 04, 00,   RF_CLIF_CFG_BR_106_I_RXA_P  CLIF_SIGPRO_RM_CONFIG1_REG
+#	A0, 0D, 06, 34, 44, 66, 0A, 00, 00,   RF_CLIF_CFG_BR_106_I_RXA_P  CLIF_ANA_RX_REG
+#	A0, 0D, 06, 3A, 4A, 56, 07, 01, 1B,   RF_CLIF_CFG_BR_212_I_TXA  CLIF_ANA_TX_SHAPE_CONTROL_REG
+#	A0, 0D, 04, 3A, 42, 68, 40,           RF_CLIF_CFG_BR_212_I_TXA  CLIF_ANA_TX_AMPLITUDE_REG
+#	A0, 0D, 03, 3A, 16, 00,               RF_CLIF_CFG_BR_212_I_TXA  CLIF_TX_UNDERSHOOT_CONFIG_REG
+#	A0, 0D, 03, 3A, 15, 00,               RF_CLIF_CFG_BR_212_I_TXA  CLIF_TX_OVERSHOOT_CONFIG_REG
+#	A0, 0D, 03, 3A, 0D, 11,               RF_CLIF_CFG_BR_212_I_TXA  CLIF_TX_DATA_MOD_REG
+#	A0, 0D, 03, 3A, 14, 11,               RF_CLIF_CFG_BR_212_I_TXA  CLIF_TX_SYMBOL23_MOD_REG
+#	A0, 0D, 06, 3C, 2D, 05, 35, 1E, 01,   RF_CLIF_CFG_BR_212_I_RXA  CLIF_SIGPRO_RM_CONFIG1_REG
+#	A0, 0D, 06, 3C, 44, 65, 09, 00, 00,   RF_CLIF_CFG_BR_212_I_RXA  CLIF_ANA_RX_REG
+#	A0, 0D, 06, 3E, 4A, 56, 07, 01, 1B,   RF_CLIF_CFG_BR_424_I_TXA  CLIF_ANA_TX_SHAPE_CONTROL_REG
+#	A0, 0D, 04, 3E, 42, 68, 40,           RF_CLIF_CFG_BR_424_I_TXA  CLIF_ANA_TX_AMPLITUDE_REG
+#	A0, 0D, 03, 3E, 16, 00,               RF_CLIF_CFG_BR_424_I_TXA  CLIF_TX_UNDERSHOOT_CONFIG_REG
+#	A0, 0D, 03, 3E, 15, 00,               RF_CLIF_CFG_BR_424_I_TXA  CLIF_TX_OVERSHOOT_CONFIG_REG
+#	A0, 0D, 03, 3E, 0D, 08,               RF_CLIF_CFG_BR_424_I_TXA  CLIF_TX_DATA_MOD_REG
+#	A0, 0D, 03, 3E, 14, 08,               RF_CLIF_CFG_BR_424_I_TXA  CLIF_TX_SYMBOL23_MOD_REG
+#	A0, 0D, 06, 40, 2D, 05, 45, 1E, 01,   RF_CLIF_CFG_BR_424_I_RXA  CLIF_SIGPRO_RM_CONFIG1_REG
+#	A0, 0D, 06, 40, 44, 65, 09, 00, 00,   RF_CLIF_CFG_BR_424_I_RXA  CLIF_ANA_RX_REG
+#	A0, 0D, 04, 42, 42, F0, 40,           RF_CLIF_CFG_BR_848_I_TXA  CLIF_ANA_TX_AMPLITUDE_REG
+#	A0, 0D, 06, 42, 4A, 11, 07, 01, 1B,   RF_CLIF_CFG_BR_848_I_TXA  CLIF_ANA_TX_SHAPE_CONTROL_REG
+#	A0, 0D, 03, 42, 16, 00,               RF_CLIF_CFG_BR_848_I_TXA  CLIF_TX_UNDERSHOOT_CONFIG_REG
+#	A0, 0D, 03, 42, 15, 00,               RF_CLIF_CFG_BR_848_I_TXA  CLIF_TX_OVERSHOOT_CONFIG_REG
+#	A0, 0D, 03, 42, 0D, 04,               RF_CLIF_CFG_BR_848_I_TXA  CLIF_TX_DATA_MOD_REG
+#	A0, 0D, 03, 42, 14, 04,               RF_CLIF_CFG_BR_848_I_TXA  CLIF_TX_SYMBOL23_MOD_REG
+#	A0, 0D, 06, 48, 44, 65, 0A, 00, 00,   RF_CLIF_CFG_BR_106_I_RXB  CLIF_ANA_RX_REG
+#	A0, 0D, 06, 48, 2D, 15, 34, 1F, 01,   RF_CLIF_CFG_BR_106_I_RXB  CLIF_SIGPRO_RM_CONFIG1_REG
+#	A0, 0D, 06, 46, 4A, 33, 07, 00, 07,   RF_CLIF_CFG_BR_106_I_TXB  CLIF_ANA_TX_SHAPE_CONTROL_REG
+#	A0, 0D, 04, 46, 42, 68, 40,           RF_CLIF_CFG_BR_106_I_TXB  CLIF_ANA_TX_AMPLITUDE_REG
+#	A0, 0D, 03, 46, 16, 00,               RF_CLIF_CFG_BR_106_I_TXB  CLIF_TX_UNDERSHOOT_CONFIG_REG
+#	A0, 0D, 03, 46, 15, 00,               RF_CLIF_CFG_BR_106_I_TXB  CLIF_TX_OVERSHOOT_CONFIG_REG
+#	A0, 0D, 06, 4C, 44, 65, 09, 00, 00,   RF_CLIF_CFG_BR_212_I_RXB  CLIF_ANA_RX_REG
+#	A0, 0D, 06, 4C, 2D, 05, 35, 1E, 01,   RF_CLIF_CFG_BR_212_I_RXB  CLIF_SIGPRO_RM_CONFIG1_REG
+#	A0, 0D, 06, 4A, 4A, 13, 07, 01, 07,   RF_CLIF_CFG_BR_212_I_TXB  CLIF_ANA_TX_SHAPE_CONTROL_REG
+#	A0, 0D, 04, 4A, 42, 68, 40,           RF_CLIF_CFG_BR_212_I_TXB  CLIF_ANA_TX_AMPLITUDE_REG
+#	A0, 0D, 03, 4A, 16, 00,               RF_CLIF_CFG_BR_212_I_TXB  CLIF_TX_UNDERSHOOT_CONFIG_REG
+#	A0, 0D, 03, 4A, 15, 00,               RF_CLIF_CFG_BR_212_I_TXB  CLIF_TX_OVERSHOOT_CONFIG_REG
+#	A0, 0D, 06, 50, 44, 65, 09, 00, 00,   RF_CLIF_CFG_BR_424_I_RXB  CLIF_ANA_RX_REG
+#	A0, 0D, 06, 50, 2D, 05, 35, 1E, 01,   RF_CLIF_CFG_BR_424_I_RXB  CLIF_SIGPRO_RM_CONFIG1_REG
+#	A0, 0D, 06, 4E, 4A, 12, 07, 01, 07,   RF_CLIF_CFG_BR_424_I_TXB  CLIF_ANA_TX_SHAPE_CONTROL_REG
+#	A0, 0D, 04, 4E, 42, 68, 40,           RF_CLIF_CFG_BR_424_I_TXB  CLIF_ANA_TX_AMPLITUDE_REG
+#	A0, 0D, 03, 4E, 16, 00,               RF_CLIF_CFG_BR_424_I_TXB  CLIF_TX_UNDERSHOOT_CONFIG_REG
+#	A0, 0D, 03, 4E, 15, 00,               RF_CLIF_CFG_BR_424_I_TXB  CLIF_TX_OVERSHOOT_CONFIG_REG
+#	A0, 0D, 04, 52, 42, 68, 40,           RF_CLIF_CFG_BR_848_I_TXB  CLIF_ANA_TX_AMPLITUDE_REG
+#	A0, 0D, 06, 52, 4A, 11, 07, 01, 07,   RF_CLIF_CFG_BR_848_I_TXB  CLIF_ANA_TX_SHAPE_CONTROL_REG
+#	A0, 0D, 03, 52, 16, 00,               RF_CLIF_CFG_BR_848_I_TXB  CLIF_TX_UNDERSHOOT_CONFIG_REG
+#	A0, 0D, 03, 52, 15, 00,               RF_CLIF_CFG_BR_848_I_TXB  CLIF_TX_OVERSHOOT_CONFIG_REG
+#	A0, 0D, 06, 58, 2D, 0D, 48, 0C, 01,   RF_CLIF_CFG_BR_212_I_RXF_P  CLIF_SIGPRO_RM_CONFIG1_REG
+#	A0, 0D, 06, 58, 44, 55, 08, 00, 00,   RF_CLIF_CFG_BR_212_I_RXF_P  CLIF_ANA_RX_REG
+#	A0, 0D, 06, 5E, 2D, 0D, 5A, 0C, 01,   RF_CLIF_CFG_BR_424_I_RXF_P  CLIF_SIGPRO_RM_CONFIG1_REG
+#	A0, 0D, 06, 5E, 44, 55, 08, 00, 00,   RF_CLIF_CFG_BR_424_I_RXF_P  CLIF_ANA_RX_REG
+#	A0, 0D, 04, 56, 42, 78, 40,           RF_CLIF_CFG_BR_212_I_TXF  CLIF_ANA_TX_AMPLITUDE_REG
+#	A0, 0D, 06, 56, 4A, 43, 07, 00, 07,   RF_CLIF_CFG_BR_212_I_TXF  CLIF_ANA_TX_SHAPE_CONTROL_REG
+#	A0, 0D, 03, 56, 16, 00,               RF_CLIF_CFG_BR_212_I_TXF  CLIF_TX_UNDERSHOOT_CONFIG_REG
+#	A0, 0D, 03, 56, 15, 00,               RF_CLIF_CFG_BR_212_I_TXF  CLIF_TX_OVERSHOOT_CONFIG_REG
+#	A0, 0D, 04, 5C, 42, 80, 40,           RF_CLIF_CFG_BR_424_I_TXF  CLIF_ANA_TX_AMPLITUDE_REG
+#	A0, 0D, 06, 5C, 4A, 11, 07, 01, 07,   RF_CLIF_CFG_BR_424_I_TXF  CLIF_ANA_TX_SHAPE_CONTROL_REG
+#	A0, 0D, 03, 5C, 16, 00,               RF_CLIF_CFG_BR_424_I_TXF  CLIF_TX_UNDERSHOOT_CONFIG_REG
+#	A0, 0D, 03, 5C, 15, 00,               RF_CLIF_CFG_BR_424_I_TXF  CLIF_TX_OVERSHOOT_CONFIG_REG
+#	A0, 0D, 06, 30, 44, 05, 04, C4, 00,   RF_CLIF_CFG_TECHNO_T_RXF  CLIF_ANA_RX_REG
+#	A0, 0D, 03, 24, 03, 7F,               RF_CLIF_CFG_TECHNO_T_TXA_P  CLIF_TRANSCEIVE_CONTROL_REG
+#	A0, 0D, 06, 7A, 16, 8E, 00, 1F, 00,   RF_CLIF_CFG_BR_848_T_TXA  CLIF_TX_UNDERSHOOT_CONFIG_REG
+#	A0, 0D, 03, 28, 16, 00,               RF_CLIF_CFG_TECHNO_T_TXB  CLIF_TX_UNDERSHOOT_CONFIG_REG
+#	A0, 0D, 03, 2C, 16, 00,               RF_CLIF_CFG_TECHNO_T_TXF_P  CLIF_TX_UNDERSHOOT_CONFIG_REG
+#	A0, 0D, 06, 70, 44, 04, 04, C4, 00,   RF_CLIF_CFG_BR_106_T_RXA  CLIF_ANA_RX_REG
+#	A0, 0D, 06, 74, 30, E0, 00, 30, 00,   RF_CLIF_CFG_BR_212_T_RXA  CLIF_SIGPRO_ADCBCM_THRESHOLD_REG
+#	A0, 0D, 03, 74, 45, 70,               RF_CLIF_CFG_BR_212_T_RXA  CLIF_ANA_CM_CONFIG_REG
+#	A0, 0D, 03, 75, 45, 60,               RF_CLIF_CFG_BR_212_T_RXA  CLIF_ANA_CM_CONFIG_REG
+#	A0, 0D, 06, 78, 30, 40, 00, 20, 00,   RF_CLIF_CFG_BR_424_T_RXA  CLIF_SIGPRO_ADCBCM_THRESHOLD_REG
+#	A0, 0D, 06, 78, 44, 02, 04, C4, 00,   RF_CLIF_CFG_BR_424_T_RXA  CLIF_ANA_RX_REG
+#	A0, 0D, 06, 7C, 30, 26, 00, 08, 00,   RF_CLIF_CFG_BR_848_T_RXA  CLIF_SIGPRO_ADCBCM_THRESHOLD_REG
+#	A0, 0D, 06, 7C, 44, 11, 00, C4, 00,   RF_CLIF_CFG_BR_848_T_RXA  CLIF_ANA_RX_REG
+#	A0, 0D, 06, 80, 30, 70, 00, 18, 00,   RF_CLIF_CFG_BR_106_T_RXB  CLIF_SIGPRO_ADCBCM_THRESHOLD_REG
+#	A0, 0D, 06, 80, 44, 04, 04, C4, 00,   RF_CLIF_CFG_BR_106_T_RXB  CLIF_ANA_RX_REG
+#	A0, 0D, 06, 84, 30, B0, 00, 45, 00,   RF_CLIF_CFG_BR_212_T_RXB  CLIF_SIGPRO_ADCBCM_THRESHOLD_REG
+#	A0, 0D, 06, 88, 30, B0, 00, 45, 00,   RF_CLIF_CFG_BR_424_T_RXB  CLIF_SIGPRO_ADCBCM_THRESHOLD_REG
+#	A0, 0D, 06, 8C, 30, 70, 00, 18, 00,   RF_CLIF_CFG_BR_848_T_RXB  CLIF_SIGPRO_ADCBCM_THRESHOLD_REG
+#	A0, 0D, 03, 92, 30, 00,               RF_CLIF_CFG_BR_212_T_RXF  CLIF_SIGPRO_ADCBCM_THRESHOLD_REG
+#	A0, 0D, 03, 93, 30, 00,               RF_CLIF_CFG_BR_212_T_RXF  CLIF_SIGPRO_ADCBCM_THRESHOLD_REG
+#	A0, 0D, 06, 08, 45, C3, 82, 71, 05,   RF_CLIF_CFG_I_PASSIVE  CLIF_ANA_CM_CONFIG_REG
+#	A0, 0D, 03, 0A, 44, 60,               RF_CLIF_CFG_I_ACTIVE  CLIF_ANA_RX_REG
+#	A0, 0D, 06, 0A, 30, 70, 00, 18, 00,   RF_CLIF_CFG_I_ACTIVE  CLIF_SIGPRO_ADCBCM_THRESHOLD_REG
+#	A0, 0D, 03, 0A, 48, 10,               RF_CLIF_CFG_I_ACTIVE  CLIF_ANA_CLK_MAN_REG
+#	A0, 0D, 06, 0A, 45, 80, 40, 00, 00,   RF_CLIF_CFG_I_ACTIVE  CLIF_ANA_CM_CONFIG_REG
+#	A0, 0D, 06, 0A, 2D, 0D, 25, 2C, 01,   RF_CLIF_CFG_I_ACTIVE  CLIF_SIGPRO_RM_CONFIG1_REG
+#	A0, 0D, 03, 0A, 35, 0C,               RF_CLIF_CFG_I_ACTIVE  CLIF_AGC_INPUT_REG
+#	A0, 0D, 06, 0B, 30, 00, 00, 00, 00,   RF_CLIF_CFG_I_ACTIVE  CLIF_SIGPRO_ADCBCM_THRESHOLD_REG
+#	A0, 0D, 03, 0B, 48, 00,               RF_CLIF_CFG_I_ACTIVE  CLIF_ANA_CLK_MAN_REG
+#	A0, 0D, 06, 0B, 85, 00, 00, 00, 00,   RF_CLIF_CFG_I_ACTIVE  CLIF_BBA_CONTROL_REG
+#	A0, 0D, 06, 1E, 44, 05, 04, C4, 00,   RF_CLIF_CFG_TECHNO_I_RXF_A  CLIF_ANA_RX_REG
+#	A0, 0D, 06, 36, 44, 04, 04, C4, 00,   RF_CLIF_CFG_BR_106_I_RXA_A  CLIF_ANA_RX_REG
+#	A0, 0D, 03, 10, 16, 00,               RF_CLIF_CFG_T_ACTIVE  CLIF_TX_UNDERSHOOT_CONFIG_REG
+#	A0, 0D, 06, 10, 37, 00, 00, 00, 00,   RF_CLIF_CFG_T_ACTIVE  CLIF_TX_CONTROL_REG
+#	A0, 0D, 03, 10, 35, 0C,               RF_CLIF_CFG_T_ACTIVE  CLIF_AGC_INPUT_REG
+#	A0, 0D, 06, C4, 42, F8, 40, FF, FF,   RF_CLIF_WL_106_T_TXA_A  CLIF_ANA_TX_AMPLITUDE_REG
+#	A0, 0D, 06, C4, 4A, 53, 07, 00, 1B,   RF_CLIF_WL_106_T_TXA_A  CLIF_ANA_TX_SHAPE_CONTROL_REG
+#	A0, 0D, 06, C6, 42, 78, 40, FF, FF,   RF_CLIF_WL_212_T_TXF_A  CLIF_ANA_TX_AMPLITUDE_REG
+#	A0, 0D, 06, C6, 4A, 43, 07, 00, 07,   RF_CLIF_WL_212_T_TXF_A  CLIF_ANA_TX_SHAPE_CONTROL_REG
+#	A0, 0D, 06, C8, 42, 80, 40, FF, FF,   RF_CLIF_WL_424_T_TXF_A  CLIF_ANA_TX_AMPLITUDE_REG
+#	A0, 0D, 06, C8, 4A, 11, 07, 01, 07,   RF_CLIF_WL_424_T_TXF_A  CLIF_ANA_TX_SHAPE_CONTROL_REG
+#	A0, 0D, 03, 6C, 16, 01,               RF_CLIF_CFG_BR_106_T_TXA_A  CLIF_TX_UNDERSHOOT_CONFIG_REG
+#	A0, 0D, 03, 6C, 15, 01,               RF_CLIF_CFG_BR_106_T_TXA_A  CLIF_TX_OVERSHOOT_CONFIG_REG
+#	A0, 0D, 03, 90, 16, 00,               RF_CLIF_CFG_BR_212_T_TXF_A  CLIF_TX_UNDERSHOOT_CONFIG_REG
+#	A0, 0D, 03, 90, 15, 00,               RF_CLIF_CFG_BR_212_T_TXF_A  CLIF_TX_OVERSHOOT_CONFIG_REG
+#	A0, 0D, 03, 96, 16, 00,               RF_CLIF_CFG_BR_424_T_TXF_A  CLIF_TX_UNDERSHOOT_CONFIG_REG
+#	A0, 0D, 03, 96, 15, 00,               RF_CLIF_CFG_BR_424_T_TXF_A  CLIF_TX_OVERSHOOT_CONFIG_REG
+#	A0, 0D, 04, CA, 42, 68, 40,           RF_CLIF_CFG_STAG  CLIF_ANA_TX_AMPLITUDE_REG
+#	A0, 0D, 06, CA, 44, 65, 0A, 00, 00,   RF_CLIF_CFG_STAG  CLIF_ANA_RX_REG
+#	A0, 0D, 06, CA, 2D, 15, 34, 1F, 01,   RF_CLIF_CFG_STAG  CLIF_SIGPRO_RM_CONFIG1_REG
+#
+# *** Eval1_SLALM_CFG2_EFM_40x20 FW VERSION = 11.01.18    ***
+
 NXP_RF_CONF_BLK_1={
-20, 02, 5C, 01, A0, 0B, 58, 10, 90, 90, 78, 0F, 4E, 32, 00, 3D, 9F, 00, 00, 3D,
-9F, 00, 00, 50, 9F, 00, 00, 59, 9F, 00, 00, 5A, 9F, 00, 00, 64, 9F, 00, 00, 65,
-9F, 00, 00, 6E, 9F, 00, 00, 72, 9F, 00, 00, 79, 9F, 00, 00, 7B, 9F, 00, 00, 84,
-9F, 00, 00, 86, 9F, 00, 00, 8F, 9F, 00, 00, 91, 9F, 00, 00, 9A, 9F, 00, 00, A1,
-9F, 00, 00, A7, 1F, 00, 00, B0, 1F, 00, 00, B9, 1F, 00, 00
+	20, 02, E7, 1B,
+	A0, 0D, 06, 06, 37, 48, 76, 00, 00,
+	A0, 0D, 03, 24, 03, 7C,
+	A0, 0D, 06, 02, 35, 00, 3E, 00, 00, 
+	A0, 0D, 06, 04, 35, F4, 05, 70, 02, 
+	A0, 0D, 06, C2, 35, 00, 3E, 00, 03,
+  	A0, 0D, 06, 04, 42, F8, 40, FF, FF, 
+  	A0, 0D, 04, 32, 42, F8, 40,
+  	A0, 0D, 04, 46, 42, 68, 40,
+  	A0, 0D, 04, 56, 42, 78, 40,
+  	A0, 0D, 04, 5C, 42, 80, 40,
+  	A0, 0D, 04, CA, 42, 68, 40,
+  	A0, 0D, 06, 06, 42, 00, 03, FF, FF,
+  	A0, 0D, 06, 32, 4A, 53, 07, 00, 1B, 
+  	A0, 0D, 06, 46, 4A, 33, 07, 00, 07,
+  	A0, 0D, 06, 56, 4A, 43, 07, 00, 07,
+  	A0, 0D, 06, 5C, 4A, 11, 07, 01, 07,
+  	A0, 0D, 06, 34, 44, 77, 0A, 00, 00, 
+  	A0, 0D, 06, 48, 44, 65, 0A, 00, 00,
+  	A0, 0D, 06, 58, 44, 77, 08, 00, 00,
+  	A0, 0D, 06, 5E, 44, 77, 08, 00, 00,
+  	A0, 0D, 06, CA, 44, 65, 0A, 00, 00,
+  	A0, 0D, 06, 06, 44, 04, 04, C4, 00,
+  	A0, 0D, 06, 34, 2D, DC, 40, 04, 00,
+	A0, 0D, 06, 48, 2D, 15, 34, 1F, 01, 
+	A0, 0D, 06, 58, 2D, 0D, 48, 0C, 01, 
+	A0, 0D, 06, 5E, 2D, 0D, 5A, 0C, 01, 
+	A0, 0D, 06, CA, 2D, 15, 34, 1F, 01
 }
 
-###############################################################################
-# NXP RF configuration ALM/PLM settings
-# This section needs to be updated with the correct values based on the platform
-# DLMA Deactivated
+
+
 NXP_RF_CONF_BLK_2={
-20, 02, D6, 01, A0, 34, D2, 23, 04, 18, 07, 40, 00, 20, 40, 00, BE, 23, 60, 00,
-2B, 13, 40, 00, B8, 21, 60, 00, 38, 35, 00, 00, 18, 46, 08, 00, DE, 54, 08, 02,
-00, 00, 08, 02, 00, 00, 08, 02, 00, 00, 08, 02, 00, 00, 08, 02, 00, 00, 08, 02,
-00, 00, 08, 02, 00, 00, 48, 01, 00, 00, 08, 03, 00, 00, 08, 01, 00, 00, C8, 02,
-00, 00, C8, 00, 00, 00, 88, 02, 00, 00, 48, 02, 00, 00, B8, 00, 00, 00, 68, 00,
-00, 00, 18, 00, 00, 00, 08, 02, 00, 00, 00, 00, 00, 00, 00, 00, 07, 00, 20, 40,
-00, BE, 23, 60, 00, 2B, 13, 40, 00, B8, 21, 60, 00, 38, 35, 00, 00, 18, 46, 08,
-00, DE, 54, 08, 02, 00, 00, 08, 02, 00, 00, 08, 02, 00, 00, 08, 02, 00, 00, 08,
-02, 00, 00, 08, 02, 00, 00, 08, 02, 00, 00, 48, 01, 00, 00, 08, 03, 00, 00, 08,
-01, 00, 00, C8, 02, 00, 00, C8, 00, 00, 00, 88, 02, 00, 00, 48, 02, 00, 00, B8,
-00, 00, 00, 68, 00, 00, 00, 18, 00, 00, 00, 08, 02, 00, 00, 00, 00
+	20, 02, D6, 01, 
+	A0, 34, D2, 23, 04, 18, 07, 40, 00, 20, 40, 00, BE, 23, 60, 00, 2B, 13, 40, 00, B8, 21, 60, 00, 38, 35, 00, 00, 18, 46, 08, 00, DE, 54, 08, 02, 00, 00, 08, 02, 00, 00, 08, 02, 00, 00, 08, 02, 00, 00, 08, 02, 00, 00, 08, 02, 00, 00, 08, 02, 00, 00, 48, 01, 00, 00, 08, 03, 00, 00, 08, 01, 00, 00, C8, 02, 00, 00, C8, 00, 00, 00, 88, 02, 00, 00, 48, 02, 00, 00, B8, 00, 00, 00, 68, 00, 00, 00, 18, 00, 00, 00, 08, 02, 00, 00, 00, 00, 00, 00, 00, 00, 07, 00, 20, 40, 00, BE, 23, 60, 00, 2B, 13, 40, 00, B8, 21, 60, 00, 38, 35, 00, 00, 18, 46, 08, 00, DE, 54, 08, 02, 00, 00, 08, 02, 00, 00, 08, 02, 00, 00, 08, 02, 00, 00, 08, 02, 00, 00, 08, 02, 00, 00, 08, 02, 00, 00, 48, 01, 00, 00, 08, 03, 00, 00, 08, 01, 00, 00, C8, 02, 00, 00, C8, 00, 00, 00, 88, 02, 00, 00, 48, 02, 00, 00, B8, 00, 00, 00, 68, 00, 00, 00, 18, 00, 00, 00, 08, 02, 00, 00, 00, 00
 }
 
-###############################################################################
-# NXP RF configuration ALM/PLM settings
-# This section needs to be updated with the correct values based on the platform
-#NXP_RF_CONF_BLK_3={
-#}
 
-###############################################################################
-# NXP RF configuration ALM/PLM settings
-# This section needs to be updated with the correct values based on the platform
-#NXP_RF_CONF_BLK_4={
-#}
-
-###############################################################################
-# NXP RF configuration ALM/PLM settings
-# This section needs to be updated with the correct values based on the platform
-#NXP_RF_CONF_BLK_5={
-#}
-
-###############################################################################
-# NXP RF configuration ALM/PLM settings
-# This section needs to be updated with the correct values based on the platform
-#NXP_RF_CONF_BLK_6={
-#}
+NXP_RF_CONF_BLK_3={
+	20, 02, 5B, 01,
+	A0, 0B, 57, 11, 11, 90, 78, 0F, 4E, 00, 3D, 95, 00, 00, 3D, 9F, 00, 00, 50, 9F, 00, 00, 59, 9F, 00, 00, 5A, 9F, 00, 00, 64, 9F, 00, 00, 65, 9F, 00, 00, 6E, 9F, 00, 00, 72, 9F, 00, 00, 79, 9F, 00, 00, 7B, 9F, 00, 00, 84, 9F, 00, 00, 86, 9F, 00, 00, 8F, 9F, 00, 00, 91, 9F, 00, 00, 9A, 9F, 00, 00, A1, 9F, 00, 00, A7, 9F, 00, 00, B0, 1F, 00, 00, B9, 1F, 00, 00
+}
 
 ###############################################################################
 # Set configuration optimization decision setting
-# Enable    = 0x01
+# Disable   = 0x00	for MP version
+# Enable    = 0x01	for RF debug
+# Modify from 0x00 to 0x01 by TCTNB.Ji.Chen
+NXP_SET_CONFIG_ALWAYS=0x01
+
+###############################################################################
+# Core configuration rf field filter settings to enable set to 01 to disable set
+# to 00 last bit
 # Disable   = 0x00
-NXP_SET_CONFIG_ALWAYS=0x00
+# Enable    = 0x01
+NXP_CORE_RF_FIELD={20, 02, 05, 01, A0, 62, 01, 00}
 
 ###############################################################################
 # Core configuration extensions
@@ -155,63 +308,70 @@ NXP_SET_CONFIG_ALWAYS=0x00
 # Clock settings A002, A003
 # PbF settings A008
 # Clock timeout settings A004
+# UICC SWP_INT1_EN_CFG - A0, EC
+# UICC2 SWP_INT2_EN_CFG - A0, ED,
 # eSE (SVDD) PWR REQ settings A0F2
-# Window size A0D8
-# DWP Speed   A0D5
 # How eSE connected to PN553 A012
-# UICC2 bit rate A0D1
+# UICC bit rate A0D1
 # SWP1A interface A0D4
-# DWP intf behavior config, SVDD Load activated by default if set to 0x31 A037
-NXP_CORE_CONF_EXTN={20, 02, 29, 0A,
+# DWP intf behavior config, SVDD Load activated by default if set to 0x31 - A037
+# For Symmetric baud rate  UICC's set A086 to 77
+NXP_CORE_CONF_EXTN={20, 02, 43, 0E,
     A0, EC, 01, 01,
-    A0, ED, 01, 01,
+    A0, ED, 01, 00,
     A0, 5E, 01, 01,
     A0, 12, 01, 02,
     A0, 40, 01, 01,
+    A0, 41, 01, 04,
+    A0, 42, 01, 19,
+    A0, 43, 01, 05,
+    A0, DD, 01, 2D,
     A0, D1, 01, 02,
     A0, D4, 01, 01,
     A0, 37, 01, 35,
-    A0, D8, 01, 02,
-    A0, D5, 01, 0A
+    A0, 38, 04, 14, 0B, 0B, 00,
+    A0, 3A, 08, 5A, 00, 5A, 00, 5A, 00, 5A, 00
    }
-#       A0, F2, 01, 01,
-#       A0, 40, 01, 01,
-#       A0, 41, 01, 02,
-#       A0, 43, 01, 04,
-#       A0, 02, 01, 01,
-#       A0, 03, 01, 11,
-#       A0, 07, 01, 03,
-#       A0, 08, 01, 01
-#       }
 
 ###############################################################################
-# Core configuration rf field filter settings to enable set to 01 to disable set
-# to 00 last bit
-NXP_CORE_RF_FIELD={ 20, 02, 05, 01, A0, 62, 01, 00 }
+# Core configuration settings
+# It includes
+# 18    - Poll Mode NFC-F:   PF_BIT_RATE
+# 21    - Poll Mode ISO-DEP: PI_BIT_RATE
+# 28    - Poll Mode NFC-DEP: PN_NFC_DEP_SPEED
+# 30    - Lis. Mode NFC-A:   LA_BIT_FRAME_SDD
+# 31    - Lis. Mode NFC-A:   LA_PLATFORM_CONFIG
+# 33    - Lis. Mode NFC-A:   LA_NFCID1
+# 50    - Lis. Mode NFC-F:   LF_PROTOCOL_TYPE
+# 54    - Lis. Mode NFC-F:   LF_CON_BITR_F
+# 5B    - Lis. Mode ISO-DEP: LI_BIT_RATE
+# 60    - Lis. Mode NFC-DEP: LN_WT
+# 80    - Other Param.:      RF_FIELD_INFO
+# 81    - Other Param.:      RF_NFCEE_ACTION
+# 82    - Other Param.:      NFCDEP_OP
+NXP_CORE_CONF={ 20, 02, 2E, 0E,
+    18, 01, 01,
+    21, 01, 00,
+    28, 01, 00,
+    30, 01, 08,
+    31, 01, 03,
+        32, 01, 20,
+    33, 04, 01, 02, 03, 04,
+    38, 01, 01,
+    50, 01, 02,
+    54, 01, 06,
+    5B, 01, 00,
+    80, 01, 01,
+    81, 01, 01,
+    82, 01, 0E
+    }
 
 ###############################################################################
 # To enable i2c fragmentation set i2c fragmentation enable 0x01 to disable set
 # to 0x00
+# Disable   = 0x00
+# Enable    = 0x01
 NXP_I2C_FRAGMENTATION_ENABLED=0x00
-
-###############################################################################
-# Core configuration settings
-NXP_CORE_CONF={ 20, 02, 2E, 0E,
-        28, 01, 00,
-        21, 01, 00,
-        30, 01, 08,
-        31, 01, 03,
-        32, 01, 60,
-        38, 01, 01,
-        33, 04, 01, 02, 03, 04,
-        54, 01, 06,
-        50, 01, 02,
-        5B, 01, 00,
-        80, 01, 01,
-        81, 01, 01,
-        82, 01, 0E,
-        18, 01, 01
-        }
 
 ###############################################################################
 # Mifare Classic Key settings
@@ -228,20 +388,11 @@ NXP_CORE_CONF={ 20, 02, 2E, 0E,
 # UICC2             0x04
 NXP_DEFAULT_SE=0x07
 
-###############################################################################
-# Force ESE to only listen to the following technology(s).
-# The bits are defined as tNFA_TECHNOLOGY_MASK in nfa_api.h.
-# Default is NFA_TECHNOLOGY_MASK_A | NFA_TECHNOLOGY_MASK_B | NFA_TECHNOLOGY_MASK_F
-NXP_ESE_LISTEN_TECH_MASK=0x07
-
-###############################################################################
-#set autonomous mode
-# disable autonomous 0x00
-# enable autonomous  0x01
-NXP_CORE_SCRN_OFF_AUTONOMOUS_ENABLE=0x00
 
 ###############################################################################
 #Enable SWP full power mode when phone is power off
+# Disable   = 0x00
+# Enable    = 0x01
 NXP_SWP_FULL_PWR_ON=0x00
 
 ###############################################################################
@@ -254,7 +405,7 @@ NXP_SWP_FULL_PWR_ON=0x00
 #PN67T              0x06
 #PN553              0x07
 #PN80T              0x08
-NXP_NFC_CHIP=0x08
+NXP_NFC_CHIP=0x07
 
 ###############################################################################
 # CE when Screen state is locked
@@ -286,7 +437,7 @@ NXP_SWP_RD_TAG_OP_TIMEOUT=0x20
 # eSE   0x01
 # UICC  0x02
 # UICC2 0x03
-DEFAULT_AID_ROUTE=0x00
+DEFAULT_AID_ROUTE=0x02
 
 ###############################################################################
 # Configure the default NfcA/IsoDep techology and protocol route. Can be
@@ -294,7 +445,7 @@ DEFAULT_AID_ROUTE=0x00
 # host  0x00
 # eSE   0x01
 # UICC  0x02
-DEFAULT_ROUTE=0x00
+DEFAULT_ROUTE=0x02
 
 ###############################################################################
 # Configure the single default SE to use.  The default is to use the first
@@ -304,7 +455,7 @@ DEFAULT_ROUTE=0x00
 # host  0x00
 # eSE   0x01
 # UICC  0x02
-DEFAULT_OFFHOST_ROUTE=0x01
+DEFAULT_OFFHOST_ROUTE=0x02
 
 ###############################################################################
 # Configure the single default SE to use.  The default is to use the first
@@ -314,14 +465,14 @@ DEFAULT_OFFHOST_ROUTE=0x01
 # host  0x00
 # eSE   0x01
 # UICC  0x02
-DEFAULT_NFCF_ROUTE=0x01
+DEFAULT_NFCF_ROUTE=0x02
 
 ###############################################################################
 #Set the default Felica T3T System Code OffHost route Location :
 #This settings will be used when application does not set this parameter
 # host  0x00
 # eSE   0xC0
-DEFAULT_SYS_CODE_ROUTE=0xC0
+DEFAULT_SYS_CODE_ROUTE=0x00
 
 ###############################################################################
 #Set the default AID Power state :
@@ -331,7 +482,7 @@ DEFAULT_SYS_CODE_ROUTE=0xC0
 # bit pos 2 = Battery Off
 # bit pos 3 = Screen Lock
 # bit pos 4 = Screen Off
-DEFAULT_AID_PWR_STATE=0x19
+DEFAULT_AID_PWR_STATE=0x1B
 
 ###############################################################################
 #Set the Mifare Desfire Power state :
@@ -369,8 +520,8 @@ DEFAULT_FELICA_CLT_PWR_STATE=0x1B
 # bit pos 0 = Switch On
 # bit pos 1 = Switch Off
 # bit pos 2 = Battery Off
-# bit pos 3 = Screen Lock
-# bit pos 4 = Screen Off
+# bit pos 3 = Screen Off
+# bit pos 4 = Screen Lock
 DEFAULT_SYS_CODE_PWR_STATE=0x1B
 
 ###############################################################################
@@ -574,27 +725,8 @@ AID_BLOCK_ROUTE=0x00
 NXP_DWP_INTF_RESET_ENABLE=0x00
 
 ###############################################################################
-# Timeout value in milliseconds for JCOP OS download to complete
-OS_DOWNLOAD_TIMEOUT_VALUE=60000
-
-###############################################################################
 # Timeout value in milliseconds to send response for Felica command received
 NXP_HCEF_CMD_RSP_TIMEOUT_VALUE=5000
-
-###############################################################################
-# Maximum WTX requests entertained by MW
-NXP_WM_MAX_WTX_COUNT=50
-
-###############################################################################
-# HAL library path for selftest
-NXP_HAL_PATH="/vendor/lib64/hw/nfc_nci.pn54x.so"
-
-###############################################################################
-# Enable or Disable RF_STATUS_UPDATE to EseHal module
-# Disable           0x00
-# Enable            0x01
-RF_STATUS_UPDATE_ENABLE=0x00
-
 ###############################################################################
 # Vendor Specific Proprietary Protocol & Discovery Configuration
 # Set to 0xFF if unsupported
@@ -624,11 +756,5 @@ PRESENCE_CHECK_ALGORITHM=2
 ###############################################################################
 # Extended APDU length for ISO_DEP
 ISO_DEP_MAX_TRANSCEIVE=0xFEFF
-
-###############################################################################
-# Disable Mifare CLT for JCOP4.1
-# Enable            0x01
-# Disable           0x00
-#NXP_MF_CLT_JCOP_CFG=0x01
 
 ###############################################################################

--- a/device.mk
+++ b/device.mk
@@ -273,21 +273,18 @@ PRODUCT_COPY_FILES += \
     frameworks/native/data/etc/android.hardware.nfc.hce.xml:$(TARGET_COPY_OUT_ODM)/etc/permissions/sku_NFC/android.hardware.nfc.hce.xml \
     frameworks/native/data/etc/android.hardware.nfc.hcef.xml:$(TARGET_COPY_OUT_ODM)/etc/permissions/sku_NFC/android.hardware.nfc.hcef.xml \
     frameworks/native/data/etc/android.hardware.nfc.xml:$(TARGET_COPY_OUT_ODM)/etc/permissions/sku_NFC/android.hardware.nfc.xml \
-    frameworks/native/data/etc/com.android.nfc_extras.xml:$(TARGET_COPY_OUT_ODM)/etc/permissions/sku_NFC/com.android.nfc_extras.xml \
-    frameworks/native/data/etc/com.nxp.mifare.xml:$(TARGET_COPY_OUT_ODM)/etc/permissions/sku_NFC/com.nxp.mifare.xml
+    frameworks/native/data/etc/com.android.nfc_extras.xml:$(TARGET_COPY_OUT_ODM)/etc/permissions/sku_NFC/com.android.nfc_extras.xml
 
 PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/configs/nfc/libnfc-nci.conf:$(TARGET_COPY_OUT_VENDOR)/etc/libnfc-nci.conf \
     $(LOCAL_PATH)/configs/nfc/libnfc-nxp.conf:$(TARGET_COPY_OUT_VENDOR)/etc/libnfc-nxp.conf
 
 PRODUCT_PACKAGES += \
-    android.hardware.nfc@1.2-service
-
-PRODUCT_PACKAGES += \
+    android.hardware.nfc@1.1-service \
+    android.hardware.nfc@1.1 \
     com.android.nfc_extras \
     NfcNci \
-    SecureElement \
-    Tag
+    Tag 
 
 # OEM Unlock reporting
 PRODUCT_DEFAULT_PROPERTY_OVERRIDES += \

--- a/manifest_nfc.xml
+++ b/manifest_nfc.xml
@@ -2,7 +2,7 @@
     <hal format="hidl">
         <name>android.hardware.nfc</name>
         <transport>hwbinder</transport>
-        <version>1.2</version>
+        <version>1.1</version>
         <interface>
             <name>INfc</name>
             <instance>default</instance>

--- a/rootdir/etc/init.qcom.asus.rc
+++ b/rootdir/etc/init.qcom.asus.rc
@@ -42,7 +42,7 @@ on boot
     chown system system /proc/tpd_gesture
     chmod 0660 /proc/tpd_gesture
 
-service vendor.nfc_hal_service /vendor/bin/hw/android.hardware.nfc@1.2-service
+service vendor.nfc_hal_service /vendor/bin/hw/android.hardware.nfc@1.1-service
     override
     class hal
     user nfc


### PR DESCRIPTION
* the stock version 438 Q uses the NFC interface version 1.1, this downgrade is made for better compatibility, mifare begins to work properly in normal mode